### PR TITLE
New methodmaps, removed default initializers for global vars

### DIFF
--- a/scripting/executes.sp
+++ b/scripting/executes.sp
@@ -40,10 +40,10 @@ bool g_Enabled = true;
 ArrayList g_SavedCvars;
 
 /** Client variable arrays **/
-int g_SpawnIndices[MAXPLAYERS + 1] = 0;
-int g_RoundPoints[MAXPLAYERS + 1] = 0;
-bool g_PluginTeamSwitch[MAXPLAYERS + 1] = false;
-int g_Team[MAXPLAYERS + 1] = 0;
+int g_SpawnIndices[MAXPLAYERS + 1];
+int g_RoundPoints[MAXPLAYERS + 1];
+bool g_PluginTeamSwitch[MAXPLAYERS + 1];
+int g_Team[MAXPLAYERS + 1];
 char g_LastItemPickup[MAXPLAYERS + 1][WEAPON_STRING_LENGTH];
 
 /** Queue Handles **/
@@ -66,13 +66,13 @@ ConVar g_DisableOtherBombSiteCvar;
 ConVar g_ExtraFreezeTimeCvar;
 
 /** Editing global variables **/
-bool g_EditMode = false;
-bool g_DirtySpawns = false;  // whether the spawns have been edited since loading from the file
+bool g_EditMode;
+bool g_DirtySpawns;  // whether the spawns have been edited since loading from the file
 
 /** Win-streak data **/
-bool g_ScrambleSignal = false;
-int g_WinStreak = 0;
-int g_RoundCount = 0;
+bool g_ScrambleSignal;
+int g_WinStreak;
+int g_RoundCount;
 
 /** Stored info from the executes config file **/
 #define MAX_SPAWNS 512
@@ -83,7 +83,7 @@ int g_RoundCount = 0;
 
 // Spawn Data
 // For the love of god we need structs...
-int g_NumSpawns = 0;
+int g_NumSpawns;
 char g_SpawnIDs[MAX_SPAWNS][ID_LENGTH];
 char g_SpawnNames[MAX_SPAWNS][SPAWN_NAME_LENGTH];
 bool g_SpawnDeleted[MAX_SPAWNS];
@@ -109,12 +109,12 @@ ArrayList g_SpawnExclusionRules[MAX_SPAWNS];  // Spawns excluded if this spawn i
 
 // Generic name buffer
 char g_TempNameBuffer[128];
-bool g_EditingExecutes = false;  // if true, editing a spawm
+bool g_EditingExecutes;  // if true, editing a spawm
 
 // Buffers for spawn editing
-bool g_EditingASpawn = false;
+bool g_EditingASpawn;
 int g_EditingSpawnIndex = -1;
-int g_NextSpawnId = 0;
+int g_NextSpawnId;
 
 int g_EditingSpawnTeam = CS_TEAM_T;
 GrenadeType g_EditingSpawnGrenadeType = GrenadeType_None;
@@ -128,10 +128,10 @@ int g_EditingSpawnThrowTime;
 int g_EditingSpawnFlags;
 
 // Execute data
-int g_SelectedExecute = 0;
+int g_SelectedExecute;
 StratType g_SelectedExecuteStrat;
 
-int g_NumExecutes = 0;
+int g_NumExecutes;
 char g_ExecuteIDs[MAX_EXECUTES][ID_LENGTH];
 char g_ExecuteNames[MAX_EXECUTES][EXECUTE_NAME_LENGTH];
 bool g_ExecuteDeleted[MAX_EXECUTES];
@@ -145,13 +145,13 @@ bool g_ExecuteFake[MAX_EXECUTES];
 float g_ExecuteExtraFreezeTime[MAX_EXECUTES];
 
 // Buffers for execute ediitng
-bool g_EditingAnExecute = false;
+bool g_EditingAnExecute;
 int g_EditingExecuteIndex = -1;
 
-int g_NextExecuteId = 0;
+int g_NextExecuteId;
 Bombsite g_EditingExecuteSite = BombsiteA;
-ArrayList g_EditingExecuteTRequired = null;
-ArrayList g_EditingExecuteTOptional = null;
+ArrayList g_EditingExecuteTRequired;
+ArrayList g_EditingExecuteTOptional;
 int g_EditingExecuteLikelihood = AVG_FRIENDLINESS;
 char g_EditingExecuteForceBombId[ID_LENGTH];
 bool g_EditingExecuteStratTypes[3];
@@ -169,44 +169,44 @@ bool g_PlayerKit[MAXPLAYERS + 1];
 
 /** Per-round information about the player setup **/
 int g_LastTeam[MAXPLAYERS + 1];
-int g_RoundStartTime = 0;
+int g_RoundStartTime;
 int g_BombOwner = -1;
 int g_CTAwper = -1;
 int g_TAwper = -1;
-int g_NumCT = 0;
-int g_NumT = 0;
-int g_ActivePlayers = 0;
-bool g_RoundSpawnsDecided = false;  // spawns are lazily decided on the first player spawn event
+int g_NumCT;
+int g_NumT;
+int g_ActivePlayers;
+bool g_RoundSpawnsDecided;  // spawns are lazily decided on the first player spawn event
 
-Handle g_SilencedM4Cookie = null;
+Handle g_SilencedM4Cookie;
 bool g_SilencedM4[MAXPLAYERS + 1];
 
-Handle g_AllowAWPCookie = null;
+Handle g_AllowAWPCookie;
 bool g_AllowAWP[MAXPLAYERS + 1];
 
 // CT
-Handle g_CZCTSideCookie = null;
+Handle g_CZCTSideCookie;
 bool g_CZCTSide[MAXPLAYERS + 1];
 
 // T
-Handle g_CZTSideCookie = null;
+Handle g_CZTSideCookie;
 bool g_CZTSide[MAXPLAYERS + 1];
 
 SitePref g_SitePreference[MAXPLAYERS + 1];
 
-int g_EndWarmupTime = 0;
+int g_EndWarmupTime;
 int g_BombSiteAIndex;
 int g_BombSiteBIndex;
 bool g_ShowingEditorInformation = true;
 
 /** Forwards **/
-Handle g_hOnGunsCommand = null;
-Handle g_hOnPostRoundEnqueue = null;
-Handle g_hOnPreRoundEnqueue = null;
-Handle g_hOnTeamSizesSet = null;
-Handle g_hOnTeamsSet = null;
-Handle g_OnRoundWon = null;
-Handle g_OnGetSpecialPowers = null;
+Handle g_hOnGunsCommand;
+Handle g_hOnPostRoundEnqueue;
+Handle g_hOnPreRoundEnqueue;
+Handle g_hOnTeamSizesSet;
+Handle g_hOnTeamsSet;
+Handle g_OnRoundWon;
+Handle g_OnGetSpecialPowers;
 
 #include "executes/editor.sp"
 #include "executes/editor_commands.sp"

--- a/scripting/executes/editor.sp
+++ b/scripting/executes/editor.sp
@@ -1,5 +1,5 @@
-int g_iBeamSprite = 0;
-int g_iHaloSprite = 0;
+int g_iBeamSprite;
+int g_iHaloSprite;
 
 public void StartEditMode() {
   g_EditMode = true;

--- a/scripting/executes/editor_menus.sp
+++ b/scripting/executes/editor_menus.sp
@@ -23,9 +23,9 @@ GiveEditorMenu(int client, int menuPosition = -1) {
   AddMenuOption(menu, "clear_edit_buffers", "Clear edit buffers");
 
   if (menuPosition == -1) {
-    DisplayMenu(menu, client, MENU_TIME_FOREVER);
+    menu.Display(client, MENU_TIME_FOREVER);
   } else {
-    DisplayMenuAtItem(menu, client, menuPosition, MENU_TIME_FOREVER);
+    menu.DisplayAt(client, menuPosition, MENU_TIME_FOREVER);
   }
 }
 
@@ -33,7 +33,7 @@ public int EditorMenuHandler(Menu menu, MenuAction action, int param1, int param
   if (action == MenuAction_Select) {
     int client = param1;
     char choice[64];
-    GetMenuItem(menu, param2, choice, sizeof(choice));
+    menu.GetItem(param2, choice, sizeof(choice));
     int menuPosition = GetMenuSelectionPosition();
 
     if (StrEqual(choice, "end_edit")) {
@@ -125,9 +125,9 @@ stock void GiveNewSpawnMenu(int client, int pos = -1) {
   menu.ExitBackButton = true;
 
   if (pos == -1) {
-    DisplayMenu(menu, client, MENU_TIME_FOREVER);
+    menu.Display(client, MENU_TIME_FOREVER);
   } else {
-    DisplayMenuAtItem(menu, client, pos, MENU_TIME_FOREVER);
+    menu.DisplayAt(client, pos, MENU_TIME_FOREVER);
   }
 }
 
@@ -136,7 +136,7 @@ public int GiveNewSpawnMenuHandler(Menu menu, MenuAction action, int param1, int
     int pos = GetMenuSelectionPosition();
     int client = param1;
     char choice[64];
-    GetMenuItem(menu, param2, choice, sizeof(choice));
+    menu.GetItem(param2, choice, sizeof(choice));
     if (StrEqual(choice, "finish")) {
       AddSpawn(client);
       GiveNewSpawnMenu(client, pos);
@@ -280,9 +280,9 @@ stock void GiveNewExecuteMenu(int client, int pos = -1) {
   menu.ExitBackButton = true;
 
   if (pos == -1) {
-    DisplayMenu(menu, client, MENU_TIME_FOREVER);
+    menu.Display(client, MENU_TIME_FOREVER);
   } else {
-    DisplayMenuAtItem(menu, client, pos, MENU_TIME_FOREVER);
+    menu.DisplayAt(client, pos, MENU_TIME_FOREVER);
   }
 }
 
@@ -293,7 +293,7 @@ public int GiveNewExecuteMenuHandler(Menu menu, MenuAction action, int param1, i
 
     int client = param1;
     char choice[64];
-    GetMenuItem(menu, param2, choice, sizeof(choice));
+    menu.GetItem(param2, choice, sizeof(choice));
     if (StrEqual(choice, "finish")) {
       AddExecute(client);
       GiveEditorMenu(client);
@@ -373,13 +373,13 @@ public void GiveForceBombSpawneMenu(int client) {
 
   menu.ExitButton = true;
   menu.ExitBackButton = true;
-  DisplayMenu(menu, client, MENU_TIME_FOREVER);
+  menu.Display(client, MENU_TIME_FOREVER);
 }
 
 public int GiveForceBombSpawneMenuHandler(Menu menu, MenuAction action, int param1, int param2) {
   if (action == MenuAction_Select) {
     int client = param1;
-    GetMenuItem(menu, param2, g_EditingExecuteForceBombId, ID_LENGTH);
+    menu.GetItem(param2, g_EditingExecuteForceBombId, ID_LENGTH);
     GiveNewExecuteMenu(client);
 
   } else if (action == MenuAction_Cancel && param2 == MenuCancel_ExitBack) {
@@ -441,9 +441,9 @@ stock void GiveExecuteSpawnsMenu(int client, int menuPosition = -1) {
     GiveNewSpawnMenu(client);
   } else {
     if (menuPosition == -1) {
-      DisplayMenu(menu, client, MENU_TIME_FOREVER);
+      menu.Display(client, MENU_TIME_FOREVER);
     } else {
-      DisplayMenuAtItem(menu, client, menuPosition, MENU_TIME_FOREVER);
+      menu.DisplayAt(client, menuPosition, MENU_TIME_FOREVER);
     }
   }
 }
@@ -452,7 +452,7 @@ public int GiveExecuteSpawnsMenuHandler(Menu menu, MenuAction action, int param1
   if (action == MenuAction_Select) {
     int client = param1;
     char info[32];
-    GetMenuItem(menu, param2, info, sizeof(info));
+    menu.GetItem(param2, info, sizeof(info));
 
     char useString[2];
     strcopy(useString, sizeof(useString), info);
@@ -510,9 +510,9 @@ stock void GiveExecuteEditMenu(int client, int menuPosition = -1) {
     delete menu;
   } else {
     if (menuPosition == -1) {
-      DisplayMenu(menu, client, MENU_TIME_FOREVER);
+      menu.Display(client, MENU_TIME_FOREVER);
     } else {
-      DisplayMenuAtItem(menu, client, menuPosition, MENU_TIME_FOREVER);
+      menu.DisplayAt(client, menuPosition, MENU_TIME_FOREVER);
     }
   }
 }
@@ -521,7 +521,7 @@ public int GiveExecuteMenuHandler(Menu menu, MenuAction action, int param1, int 
   if (action == MenuAction_Select) {
     int client = param1;
     char id[ID_LENGTH];
-    GetMenuItem(menu, param2, id, sizeof(id));
+    menu.GetItem(param2, id, sizeof(id));
     int execute = ExecuteIdToIndex(id);
 
     g_TempNameBuffer = g_ExecuteNames[execute];
@@ -574,9 +574,9 @@ stock void GiveEditSpawnChoiceMenu(int client, int menuPosition = -1) {
     delete menu;
   } else {
     if (menuPosition == -1) {
-      DisplayMenu(menu, client, MENU_TIME_FOREVER);
+      menu.Display(client, MENU_TIME_FOREVER);
     } else {
-      DisplayMenuAtItem(menu, client, menuPosition, MENU_TIME_FOREVER);
+      menu.DisplayAt(client, menuPosition, MENU_TIME_FOREVER);
     }
   }
 }
@@ -585,7 +585,7 @@ public int GiveEditSpawnChoiceMenuHandler(Menu menu, MenuAction action, int para
   if (action == MenuAction_Select) {
     int client = param1;
     char id[ID_LENGTH];
-    GetMenuItem(menu, param2, id, sizeof(id));
+    menu.GetItem(param2, id, sizeof(id));
     int spawn = SpawnIdToIndex(id);
     EditSpawn(client, spawn);
 

--- a/scripting/executes/execute_setup.sp
+++ b/scripting/executes/execute_setup.sp
@@ -115,7 +115,7 @@ public void SelectRoundLoadouts() {
 public void AssignTSpawns(int tCount, int ctCount, Bombsite site) {
   ArrayList chosenSpawns = new ArrayList();
   ArrayList clients = new ArrayList();
-  for (int i = 1; i <= MAXPLAYERS; i++) {
+  for (int i = 1; i <= MaxClients; i++) {
     if (IsPlayer(i) && g_Team[i] == CS_TEAM_T) {
       clients.Push(i);
     }
@@ -351,7 +351,7 @@ public void AssignCTSpawns(int tCount, int ctCount, Bombsite site) {
 
   ArrayList chosenSpawns = new ArrayList();
   ArrayList clients = new ArrayList();
-  for (int i = 1; i <= MAXPLAYERS; i++) {
+  for (int i = 1; i <= MaxClients; i++) {
     if (IsPlayer(i) && g_Team[i] == CS_TEAM_CT) {
       clients.Push(i);
     }
@@ -737,7 +737,7 @@ public void SetupThrowNade(float timeUntilFreezeEnd, int client, int spawn) {
       time = timeUntilFreezeEnd + 0.01;
     }
 
-    DataPack pack = CreateDataPack();
+    DataPack pack = new DataPack();
     pack.WriteCell(GetClientSerial(client));
     pack.WriteCell(spawn);
     CreateTimer(time, Timer_ThrowNade, pack);

--- a/scripting/executes/prefs_menu.sp
+++ b/scripting/executes/prefs_menu.sp
@@ -1,18 +1,18 @@
 public void GivePreferencesMenu(int client) {
-  Handle menu = CreateMenu(PreferencesMenuHandler);
+  Menu menu = new Menu(PreferencesMenuHandler);
   char buffer[128];
 
-  SetMenuTitle(menu, "Select weapon preferences");
+  menu.SetTitle("Select weapon preferences");
 
   buffer = "M4 choice: M4A4";
   if (g_SilencedM4[client])
     buffer = "M4 choice: M4A1-S";
-  AddMenuItem(menu, "silenced_m4", buffer);
+  menu.AddItem("silenced_m4", buffer);
 
   buffer = "Allow receiving awps: no";
   if (g_AllowAWP[client])
     buffer = "Allow receiving awps: yes";
-  AddMenuItem(menu, "allow_awp", buffer);
+  menu.AddItem("allow_awp", buffer);
 
   char choice[8];
   switch (g_SitePreference[client]) {
@@ -26,28 +26,28 @@ public void GivePreferencesMenu(int client) {
       choice = "none";
   }
   Format(buffer, sizeof(buffer), "CT site preference: %s", choice);
-  AddMenuItem(menu, "site_pref", buffer);
+  menu.AddItem("site_pref", buffer);
 
   buffer = "CZ/Five-Seven choice: Five-Seven";
   if (g_CZCTSide[client]) {
     buffer = "CZ/Five-Seven choice: CZ";
   }
-  AddMenuItem(menu, "cz_ct", buffer);
+  menu.AddItem("cz_ct", buffer);
 
   buffer = "CZ/Tec9 choice: Tec9";
   if (g_CZTSide[client]) {
     buffer = "CZ/Tec9 choice: CZ";
   }
-  AddMenuItem(menu, "cz_t", buffer);
+  menu.AddItem("cz_t", buffer);
 
-  DisplayMenu(menu, client, 15);
+  menu.Display(client, 15);
 }
 
-public int PreferencesMenuHandler(Handle menu, MenuAction action, int param1, int param2) {
+public int PreferencesMenuHandler(Menu menu, MenuAction action, int param1, int param2) {
   if (action == MenuAction_Select) {
     int client = param1;
     char choice[64];
-    GetMenuItem(menu, param2, choice, sizeof(choice));
+    menu.GetItem(param2, choice, sizeof(choice));
 
     if (StrEqual(choice, "silenced_m4")) {
       g_SilencedM4[client] = !g_SilencedM4[client];

--- a/scripting/executes/util.sp
+++ b/scripting/executes/util.sp
@@ -105,13 +105,13 @@ stock bool IsPlayer(int client) {
   return IsValidClient(client) && !IsFakeClient(client);
 }
 
-stock void AddMenuOption(Menu menu, const char[] info, const char[] display, any:...) {
+stock void AddMenuOption(Menu menu, const char[] info, const char[] display, any ...) {
   char formattedDisplay[128];
   VFormat(formattedDisplay, sizeof(formattedDisplay), display, 4);
   menu.AddItem(info, formattedDisplay);
 }
 
-stock void AddMenuOptionDisabled(Menu menu, const char[] info, const char[] display, any:...) {
+stock void AddMenuOptionDisabled(Menu menu, const char[] info, const char[] display, any ...) {
   char formattedDisplay[128];
   VFormat(formattedDisplay, sizeof(formattedDisplay), display, 4);
   menu.AddItem(info, formattedDisplay, ITEMDRAW_DISABLED);
@@ -120,34 +120,34 @@ stock void AddMenuOptionDisabled(Menu menu, const char[] info, const char[] disp
 /**
  * Adds an integer to a menu as a string choice.
  */
-stock void AddMenuInt(Handle menu, int value, const char[] display) {
+stock void AddMenuInt(Menu menu, int value, const char[] display) {
   char buffer[INTEGER_STRING_LENGTH];
   IntToString(value, buffer, sizeof(buffer));
-  AddMenuItem(menu, buffer, display);
+  menu.AddItem(buffer, display);
 }
 
 /**
  * Adds an integer to a menu as a string choice with the integer as the display.
  */
-stock void AddMenuInt2(Handle menu, int value) {
+stock void AddMenuInt2(Menu menu, int value) {
   char buffer[INTEGER_STRING_LENGTH];
   IntToString(value, buffer, sizeof(buffer));
-  AddMenuItem(menu, buffer, buffer);
+  menu.AddItem(buffer, buffer);
 }
 
 /**
  * Gets an integer to a menu from a string choice.
  */
-stock int GetMenuInt(Handle menu, int param2) {
+stock int GetMenuInt(Menu menu, int param2) {
   char choice[INTEGER_STRING_LENGTH];
-  GetMenuItem(menu, param2, choice, sizeof(choice));
+  menu.GetItem(param2, choice, sizeof(choice));
   return StringToInt(choice);
 }
 
 /**
  * Adds a boolean to a menu as a string choice.
  */
-stock void AddMenuBool(Handle menu, bool value, const char[] display) {
+stock void AddMenuBool(Menu menu, bool value, const char[] display) {
   int convertedInt = value ? 1 : 0;
   AddMenuInt(menu, convertedInt, display);
 }
@@ -155,15 +155,15 @@ stock void AddMenuBool(Handle menu, bool value, const char[] display) {
 /**
  * Gets a boolean to a menu from a string choice.
  */
-stock bool GetMenuBool(Handle menu, int param2) {
+stock bool GetMenuBool(Menu menu, int param2) {
   return GetMenuInt(menu, param2) != 0;
 }
 
 /**
  * Returns a random index from an array.
  */
-stock int RandomIndex(Handle array) {
-  int len = GetArraySize(array);
+stock int RandomIndex(ArrayList array) {
+  int len = array.Length;
   if (len == 0)
     ThrowError("Can't get random index from empty array");
   return GetRandomInt(0, len - 1);
@@ -172,8 +172,8 @@ stock int RandomIndex(Handle array) {
 /**
  * Returns a random element from an array.
  */
-stock int RandomElement(Handle array) {
-  return GetArrayCell(array, RandomIndex(array));
+stock int RandomElement(ArrayList array) {
+  return array.Get(RandomIndex(array));
 }
 
 /**
@@ -188,7 +188,7 @@ stock bool GetRandomBool() {
  */
 stock Handle FindNamedCookie(const char[] cookieName) {
   Handle cookie = FindClientCookie(cookieName);
-  if (cookie == INVALID_HANDLE) {
+  if (cookie == null) {
     cookie = RegClientCookie(cookieName, "", CookieAccess_Protected);
   }
   return cookie;
@@ -200,7 +200,7 @@ stock Handle FindNamedCookie(const char[] cookieName) {
 stock void SetCookieStringByName(int client, const char[] cookieName, const char[] value) {
   Handle cookie = FindNamedCookie(cookieName);
   SetClientCookie(client, cookie, value);
-  CloseHandle(cookie);
+  delete cookie;
 }
 
 /**
@@ -209,7 +209,7 @@ stock void SetCookieStringByName(int client, const char[] cookieName, const char
 stock void GetCookieStringByName(int client, const char[] cookieName, char[] buffer, int length) {
   Handle cookie = FindNamedCookie(cookieName);
   GetClientCookie(client, cookie, buffer, length);
-  CloseHandle(cookie);
+  delete cookie;
 }
 
 /**


### PR DESCRIPTION
For reference, any time a single dimentional array is initialized, can't use
`bool var[size] = false;`

Must use:
`bool var[size] = {false, ...};`